### PR TITLE
Middleware import fix

### DIFF
--- a/preventconcurrentlogins/middleware.py
+++ b/preventconcurrentlogins/middleware.py
@@ -2,7 +2,7 @@ from django.contrib.sessions.models import Session
 from django.conf import settings
 from django.utils.importlib import import_module
 
-from models import Visitor
+from preventconcurrentlogins.models import Visitor
 
 engine = import_module(settings.SESSION_ENGINE)
 


### PR DESCRIPTION
The development server was saying that "models" was unknown, and adding
the module name to the beginning of the import fixes this.