### PR TITLE
Allow a preceding middleware to opt out of the check

### DIFF
--- a/preventconcurrentlogins/middleware.py
+++ b/preventconcurrentlogins/middleware.py
@@ -1,4 +1,3 @@
-from django.contrib.sessions.models import Session
 from django.conf import settings
 from django import VERSION as DJANGO_VERSION
 from django.utils import deprecation
@@ -8,6 +7,7 @@ from preventconcurrentlogins.models import Visitor
 
 engine = import_module(settings.SESSION_ENGINE)
 
+
 class PreventConcurrentLoginsMiddleware(deprecation.MiddlewareMixin if DJANGO_VERSION >= (1, 10, 0) else object):
     """
     Django middleware that prevents multiple concurrent logins..
@@ -15,6 +15,10 @@ class PreventConcurrentLoginsMiddleware(deprecation.MiddlewareMixin if DJANGO_VE
     """
 
     def process_request(self, request):
+        # allow a preceding middleware to opt out of the prevent concurrent logins check
+        if getattr(request, '_allow_concurrent_logins', False):
+            return
+
         if request.user.is_authenticated():
             key_from_cookie = request.session.session_key
             if hasattr(request.user, 'visitor'):


### PR DESCRIPTION
Hi!

I had a use case where I want certain requests to opt out from the concurrent login check. I implemented that by having a middleware add `_allow_concurrent_logins` to the request object with any value that evaluates to True. The preventconcurrentlogins middleware checks for this flag and exits early when it is set.

Figured I'd make a PR in case you are interested in including this.

Thanks,
Daniel